### PR TITLE
Fix lib Math linking in CMake

### DIFF
--- a/src/filter/alpha0ps/CMakeLists.txt
+++ b/src/filter/alpha0ps/CMakeLists.txt
@@ -13,6 +13,10 @@ add_library (alpha0ps MODULE ${O_SOURCES})
 add_library (alphagrad MODULE ${G_SOURCES})
 add_library (alphaspot MODULE ${S_SOURCES})
 
+target_link_libraries(alpha0ps -lm)
+target_link_libraries(alphagrad -lm)
+target_link_libraries(alphaspot -lm)
+
 set_target_properties (alpha0ps PROPERTIES PREFIX "")
 set_target_properties (alphagrad PROPERTIES PREFIX "")
 set_target_properties (alphaspot PROPERTIES PREFIX "")

--- a/src/filter/blur/CMakeLists.txt
+++ b/src/filter/blur/CMakeLists.txt
@@ -6,6 +6,7 @@ if (MSVC)
   set (SOURCES ${SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (${TARGET}  MODULE ${SOURCES})
 set_target_properties (${TARGET} PROPERTIES PREFIX "")
 

--- a/src/filter/colgate/CMakeLists.txt
+++ b/src/filter/colgate/CMakeLists.txt
@@ -6,6 +6,7 @@ if (MSVC)
   set (SOURCES ${SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (${TARGET}  MODULE ${SOURCES})
 set_target_properties (${TARGET} PROPERTIES PREFIX "")
 

--- a/src/filter/coloradj/CMakeLists.txt
+++ b/src/filter/coloradj/CMakeLists.txt
@@ -6,6 +6,7 @@ if (MSVC)
   set (SOURCES ${SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (${TARGET} MODULE ${SOURCES})
 set_target_properties (${TARGET} PROPERTIES PREFIX "")
 

--- a/src/filter/defish0r/CMakeLists.txt
+++ b/src/filter/defish0r/CMakeLists.txt
@@ -6,6 +6,7 @@ if (MSVC)
   set (SOURCES ${SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (${TARGET}  MODULE ${SOURCES})
 set_target_properties (${TARGET} PROPERTIES PREFIX "")
 

--- a/src/filter/denoise/CMakeLists.txt
+++ b/src/filter/denoise/CMakeLists.txt
@@ -6,6 +6,7 @@ if (MSVC)
   set (SOURCES ${SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (${TARGET}  MODULE ${SOURCES})
 set_target_properties (${TARGET} PROPERTIES PREFIX "")
 

--- a/src/filter/gamma/CMakeLists.txt
+++ b/src/filter/gamma/CMakeLists.txt
@@ -6,6 +6,7 @@ if (MSVC)
   set (SOURCES ${SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (${TARGET}  MODULE ${SOURCES})
 set_target_properties (${TARGET} PROPERTIES PREFIX "")
 

--- a/src/filter/hueshift0r/CMakeLists.txt
+++ b/src/filter/hueshift0r/CMakeLists.txt
@@ -6,6 +6,7 @@ if (MSVC)
   set (SOURCES ${SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (${TARGET}  MODULE ${SOURCES})
 set_target_properties (${TARGET} PROPERTIES PREFIX "")
 

--- a/src/filter/rgbnoise/CMakeLists.txt
+++ b/src/filter/rgbnoise/CMakeLists.txt
@@ -6,6 +6,7 @@ if (MSVC)
   set (SOURCES ${SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (${TARGET}  MODULE ${SOURCES})
 set_target_properties (${TARGET} PROPERTIES PREFIX "")
 

--- a/src/generator/test_pat/CMakeLists.txt
+++ b/src/generator/test_pat/CMakeLists.txt
@@ -15,6 +15,7 @@ if (MSVC)
   set (R_SOURCES ${R_SOURCES} ${FREI0R_DEF})
 endif (MSVC)
 
+link_libraries(m)
 add_library (test_pat_B MODULE ${B_SOURCES})
 add_library (test_pat_C MODULE ${C_SOURCES})
 add_library (test_pat_G MODULE ${G_SOURCES})


### PR DESCRIPTION
Without these explicit linking, we get errors like:
/usr/bin/melt: symbol lookup error: /usr/lib/frei0r-1/colgate.so: undefined symbol: lrintf"

in Ubuntu 15.10